### PR TITLE
Updated python calls to python3

### DIFF
--- a/setup/terraform/cdsw_config.tf
+++ b/setup/terraform/cdsw_config.tf
@@ -37,7 +37,7 @@ resource "null_resource" "configure-cdsw" {
     inline = [
       "set -x",
       "set -e",
-      "nohup python -u /tmp/cdsw_setup.py $(curl ifconfig.me 2>/dev/null) /tmp/iot_model.pkl > /tmp/cdsw_setup.log 2>&1 &",
+      "nohup python3 -u /tmp/cdsw_setup.py $(curl ifconfig.me 2>/dev/null) /tmp/iot_model.pkl > /tmp/cdsw_setup.log 2>&1 &",
       "sleep 1 # don't remove - needed for the nohup to work",
     ]
   }

--- a/setup/terraform/common.sh
+++ b/setup/terraform/common.sh
@@ -12,7 +12,7 @@ function check_env_files() {
 }
 
 function check_python_modules() {
-  python -c '
+  python3 -c '
 missing_modules = []
 try:
   import yaml

--- a/setup/terraform/launch.sh
+++ b/setup/terraform/launch.sh
@@ -19,7 +19,7 @@ check_python_modules
 
 # Check if enddate is close
 WARNING_THRESHOLD_DAYS=2
-DATE_CHECK=$(python -c "
+DATE_CHECK=$(python3 -c "
 from datetime import datetime, timedelta
 dt = datetime.now()
 dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -47,7 +47,7 @@ source $BASE_DIR/resources/common.sh
 load_stack $NAMESPACE $BASE_DIR/resources local
 log "Validate services selection: $CM_SERVICES"
 CLUSTER_HOST=dummy PRIVATE_IP=dummy PUBLIC_DNS=dummy DOCKER_DEVICE=dummy CDSW_DOMAIN=dummy \
-python $BASE_DIR/resources/cm_template.py --cdh-major-version $CDH_MAJOR_VERSION $CM_SERVICES --validate-only
+python3 $BASE_DIR/resources/cm_template.py --cdh-major-version $CDH_MAJOR_VERSION $CM_SERVICES --validate-only
 
 log "Check for parcels"
 chmod +x $BASE_DIR/resources/check-for-parcels.sh

--- a/setup/terraform/resources/setup.sh
+++ b/setup/terraform/resources/setup.sh
@@ -379,7 +379,7 @@ export CDSW_DOMAIN=cdsw.${PUBLIC_IP}.nip.io
 export CLUSTER_HOST=$(hostname -f)
 export PRIVATE_IP=$(hostname -I | tr -d '[:space:]')
 export DOCKER_DEVICE PUBLIC_DNS
-python $BASE_DIR/cm_template.py --cdh-major-version $CDH_MAJOR_VERSION $CM_SERVICES > $TEMPLATE_FILE
+python3 $BASE_DIR/cm_template.py --cdh-major-version $CDH_MAJOR_VERSION $CM_SERVICES > $TEMPLATE_FILE
 
 echo "-- Create cluster"
 if [ "$(is_kerberos_enabled)" == "yes" ]; then
@@ -388,7 +388,7 @@ else
   KERBEROS_OPTION=""
 fi
 CM_REPO_URL=$(grep baseurl $CM_REPO_FILE | sed 's/.*=//;s/ //g')
-python $BASE_DIR/create_cluster.py $KERBEROS_OPTION $(hostname -f) $TEMPLATE_FILE $KEY_FILE $CM_REPO_URL
+python3 $BASE_DIR/create_cluster.py $KERBEROS_OPTION $(hostname -f) $TEMPLATE_FILE $KEY_FILE $CM_REPO_URL
 
 echo "-- Configure and start EFM"
 retries=0


### PR DESCRIPTION
In terraform scripts, I updated to reference the python3 binary direct mainly to avoid conflicts with python environments in mac os x.